### PR TITLE
Python 3.9 is included

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,7 @@ Ubuntu xenial (16.04) docker images (64-bit) with Pythons:
 * 3.6
 * 3.7
 * 3.8
+* 3.9
 
 installed via ``apt-get install python2.7-dev`` (etc).
 

--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Pythons 2.7 3.5 3.6 3.7 3.8 and matching pips
+# Install Pythons 2.7 3.5 3.6 3.7 3.8 3.9 and matching pips
 set -ex
 
 echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main" > /etc/apt/sources.list.d/deadsnakes.list


### PR DESCRIPTION
Updated README and a comment to mention Python 3.9, since it is also included
https://github.com/multi-build/docker-images/blob/19b445266983011ec0ed16005112b2b79f50d7e9/docker/build_install_pythons.sh#L17