### PR TITLE
pip no longer supports Python 2.7 and 3.5

### DIFF
--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -7,8 +7,15 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A755776
 apt-get update
 apt-get install -y wget
 PIP_ROOT_URL="https://bootstrap.pypa.io"
+for pyver in 2.7 3.5; do
+    pybin=python$pyver
+    apt-get install -y ${pybin} ${pybin}-dev ${pybin}-tk
+    wget $PIP_ROOT_URL/$pyver/get-pip.py -O get-pip-$pyver.py
+    get_pip_fname="get-pip-${pyver}.py"
+    ${pybin} ${get_pip_fname}
+done
 wget $PIP_ROOT_URL/get-pip.py
-for pyver in 2.7 3.5 3.6 3.7; do
+for pyver in 3.6 3.7; do
     pybin=python$pyver
     apt-get install -y ${pybin} ${pybin}-dev ${pybin}-tk
     get_pip_fname="get-pip.py"
@@ -77,7 +84,7 @@ fi
 # Compiled Pythons need to be flagged in the choose_python.sh script.
 compile_python 2.7.11 "--enable-unicode=ucs2"
 # Get pip for narrow unicode Python
-/opt/cp27m/bin/python get-pip.py
+/opt/cp27m/bin/python get-pip-2.7.py
 
 # Compiled Pythons need to be flagged in the choose_python.sh script.
 #compile_python 3.8.0rc1 "--with-openssl=/usr/local/ssl"


### PR DESCRIPTION
You can see at https://pypi.org/project/pip/ that it 'Requires: Python >=3.6'

Fixes failures seen in #6 - https://travis-ci.com/github/multi-build/docker-images/jobs/480933865#L688
```
+ python2.7 get-pip.py
Traceback (most recent call last):
  File "get-pip.py", line 24244, in <module>
    main()
  File "get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/tmp/tmpzHnbCb/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
```