### PR TITLE
Python 3.4 has been removed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,8 @@ Ubuntu xenial 64-bit images with Pythons installed
 
 Ubuntu xenial (16.04) docker images (64-bit) with Pythons:
 
-* 2.7;
-* 3.4;
-* 3.5;
+* 2.7
+* 3.5
 * 3.6
 * 3.7
 * 3.8


### PR DESCRIPTION
https://github.com/multi-build/docker-images/commit/7535473 removed Python 3.4 from build_install_pythons.sh, but this change was not reflected in the README

This PR updates the README.