### PR TITLE
Updated get-pip URL for specific versions

### DIFF
--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -10,7 +10,7 @@ PIP_ROOT_URL="https://bootstrap.pypa.io"
 for pyver in 2.7 3.5; do
     pybin=python$pyver
     apt-get install -y ${pybin} ${pybin}-dev ${pybin}-tk
-    wget $PIP_ROOT_URL/$pyver/get-pip.py -O get-pip-$pyver.py
+    wget $PIP_ROOT_URL/pip/$pyver/get-pip.py -O get-pip-$pyver.py
     get_pip_fname="get-pip-${pyver}.py"
     ${pybin} ${get_pip_fname}
 done


### PR DESCRIPTION
https://bootstrap.pypa.io/3.5/get-pip.py now instructs users to use https://bootstrap.pypa.io/pip/3.5/get-pip.py instead. The same for 2.7.