### PR TITLE
Default get-pip.py no longer supports Python 3.6

### DIFF
--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -7,7 +7,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A755776
 apt-get update
 apt-get install -y wget
 PIP_ROOT_URL="https://bootstrap.pypa.io"
-for pyver in 2.7 ; do
+for pyver in 2.7 3.6; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk
     wget $PIP_ROOT_URL/pip/$pyver/get-pip.py -O get-pip-$pyver.py
@@ -15,7 +15,7 @@ for pyver in 2.7 ; do
     ${pybin} ${get_pip_fname}
 done
 wget $PIP_ROOT_URL/get-pip.py
-for pyver in 3.6 3.7; do
+for pyver in 3.7; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk
     get_pip_fname="get-pip.py"


### PR DESCRIPTION
https://bootstrap.pypa.io/get-pip.py
> min_version = (3, 7)