### PR TITLE
Added --with-shared when compiling on Alpine

### DIFF
--- a/docker/Dockerfile-alpine3.14-x86_64
+++ b/docker/Dockerfile-alpine3.14-x86_64
@@ -70,6 +70,7 @@ RUN set -eux; \
             --with-system-expat \
             --with-system-ffi \
             --without-ensurepip \
+            --with-shared \
          && make -j "$(nproc)" \
             # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()
             # https://github.com/alpinelinux/aports/commit/2026e1259422d4e0cf92391ca2d3844356c649d0


### PR DESCRIPTION
Trying to use the alpine image for pillow-wheels, I hit
> [ImportError: Error loading shared library libffi.so.7: No such file or directory (needed by /usr/lib/python3.10/lib-dynload/_ctypes.cpython-310-x86_64-linux-gnu.so)](https://github.com/radarhere/pillow-wheels/runs/5582403106#step:4:6554)

Googling, I found this error occurring for another user with Python on Alpine - https://github.com/jfloff/alpine-python/issues/48.
This was solved by https://github.com/jfloff/alpine-python/commit/2682e394125fe0cf57cb12720ba863e3a79a4557, using `--with-shared`.

