### PR TITLE
Fixed tkinter in Alpine

### DIFF
--- a/docker/Dockerfile-alpine3.15-x86_64
+++ b/docker/Dockerfile-alpine3.15-x86_64
@@ -61,7 +61,6 @@ RUN set -eux; \
          cd /usr/src/python \
          && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
          && ./configure \
-            --prefix=/usr \
             --build="$gnuArch" \
             --enable-loadable-sqlite-extensions \
             --enable-optimizations \
@@ -80,16 +79,16 @@ RUN set -eux; \
        && rm -rf /usr/src/python ; \
     done \
     \
-    && find /usr -depth \
+    && find /usr/local -depth \
             \( \
                     \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
                     -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
             \) -exec rm -rf '{}' + \
     \
-    && find /usr -type f -executable -not \( -name '*tkinter*' \) -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
+    && find /usr/local -type f -executable -exec scanelf --needed --nobanner --format '%n#p' '{}' ';' \
        | tr ',' '\n' \
        | sort -u \
-       | awk 'system("[ -e /usr/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+       | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
        | xargs -rt apk add --no-cache --virtual .python-rundeps \
     \
     && apk del --no-network .fetch-deps \
@@ -110,12 +109,12 @@ RUN set -ex; \
        \) -exec rm -rf '{}' + \
     && rm -rf ~/.cache \
     \
-    && ln -s /usr/bin/python3 /usr/bin/python \
+    && ln -s /usr/local/bin/python3 /usr/local/bin/python \
     \
     # Install virtualenv
     && python3 -m pip install virtualenv \
     && mkdir -p ~/.local/bin \
-    && ln -s /usr/bin/virtualenv ~/.local/bin/virtualenv
+    && ln -s /usr/local/bin/virtualenv ~/.local/bin/virtualenv
 
 # Run Python selection on way into image
 COPY choose_python.sh /usr/bin/

--- a/docker/Dockerfile-alpine3.15-x86_64
+++ b/docker/Dockerfile-alpine3.15-x86_64
@@ -2,7 +2,7 @@
 
 FROM alpine:3.15
 
-ENV PYTHON_VERSIONS="3.8.13 3.9.11 3.10.3"
+ENV PYTHON_VERSIONS="3.8.13 3.9.12 3.10.4"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.


### PR DESCRIPTION
I was unable to use tkinter with Alpine.

Taking a look at
https://github.com/multi-build/docker-images/blob/6f274490af5202038719235b2bc8e9df2a16f440/docker/Dockerfile-alpine3.15-x86_64#L1
I found that the docker-library version worked. Comparing the differences, and looking at https://github.com/docker-library/python/issues/484, I've come up with this PR.

This is sort of take two at #30, since it also fixes the problem importing ctypes.