### PR TITLE
Updated Alpine to 3.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
    - arch: s390x
      env: DIST="focal" PLATFORM="s390x"
    - arch: amd64
-     env: DIST="alpine3.15" PLATFORM="x86_64"
+     env: DIST="alpine3.16" PLATFORM="x86_64"
 
 script:
   - DIST=$DIST PLATFORM=$PLATFORM TRAVIS_COMMIT=$TRAVIS_COMMIT ./build.sh

--- a/docker/Dockerfile-alpine3.16-x86_64
+++ b/docker/Dockerfile-alpine3.16-x86_64
@@ -1,6 +1,6 @@
 # based on https://github.com/docker-library/python/blob/8d48af512dc58e9c29c9d4ee59477c195a29cbdc/3.10/alpine3.13/Dockerfile
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV PYTHON_VERSIONS="3.8.13 3.9.12 3.10.4"
 

--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -7,21 +7,22 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A755776
 apt-get update
 apt-get install -y wget
 PIP_ROOT_URL="https://bootstrap.pypa.io"
-for pyver in 2.7 3.6; do
+for pyver in 2.7; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk
     wget $PIP_ROOT_URL/pip/$pyver/get-pip.py -O get-pip-$pyver.py
     get_pip_fname="get-pip-${pyver}.py"
     ${pybin} ${get_pip_fname}
 done
-wget $PIP_ROOT_URL/get-pip.py
-for pyver in 3.7; do
+for pyver in 3.6; do
     pybin=python$pyver
-    apt install -y ${pybin} ${pybin}-dev ${pybin}-tk
-    get_pip_fname="get-pip.py"
+    apt install -y ${pybin} ${pybin}-dev ${pybin}-tk ${pybin}-distutils
+    wget $PIP_ROOT_URL/pip/$pyver/get-pip.py -O get-pip-$pyver.py
+    get_pip_fname="get-pip-${pyver}.py"
     ${pybin} ${get_pip_fname}
 done
-for pyver in 3.8 3.9 3.10; do
+wget $PIP_ROOT_URL/get-pip.py
+for pyver in 3.7 3.8 3.9 3.10; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk ${pybin}-distutils
     get_pip_fname="get-pip.py"


### PR DESCRIPTION
Updated Alpine to 3.16

I've also found that distutils is now required for Python [3.6](https://app.travis-ci.com/github/multi-build/docker-images/jobs/573760919) and [3.7](https://app.travis-ci.com/github/multi-build/docker-images/jobs/573761629).