### PR TITLE
Added Python 3.12 beta

### DIFF
--- a/docker/Dockerfile-alpine3.18-arm64v8
+++ b/docker/Dockerfile-alpine3.18-arm64v8
@@ -3,7 +3,7 @@
 FROM  --platform=linux/arm64/v8 alpine:3.18
 
 ARG PLATFORM=arm64v8
-ENV PYTHON_VERSIONS="3.8.15 3.9.15 3.10.8 3.11.0"
+ENV PYTHON_VERSIONS="3.8.16 3.9.16 3.10.11 3.11.3 3.12.0b1"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
@@ -68,7 +68,6 @@ RUN set -eux; \
             --enable-option-checking=fatal \
             --enable-shared \
             --with-system-expat \
-            --with-system-ffi \
             --without-ensurepip \
          && make -j "$(nproc)" \
             # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()

--- a/docker/Dockerfile-alpine3.18-x86_64
+++ b/docker/Dockerfile-alpine3.18-x86_64
@@ -2,7 +2,7 @@
 
 FROM alpine:3.18
 
-ENV PYTHON_VERSIONS="3.8.15 3.9.15 3.10.8 3.11.0"
+ENV PYTHON_VERSIONS="3.8.16 3.9.16 3.10.11 3.11.3 3.12.0b1"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
@@ -67,7 +67,6 @@ RUN set -eux; \
             --enable-option-checking=fatal \
             --enable-shared \
             --with-system-expat \
-            --with-system-ffi \
             --without-ensurepip \
          && make -j "$(nproc)" \
             # set thread stack size to 1MB so we don't segfault before we hit sys.getrecursionlimit()

--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Pythons 2.7 3.6 3.7 3.8 3.9 3.10 3.11 and matching pips
+# Install Pythons 2.7 3.6 3.7 3.8 3.9 3.10 3.11 3.12 and matching pips
 set -ex
 
 echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes.list
@@ -22,7 +22,7 @@ for pyver in 3.6; do
     ${pybin} ${get_pip_fname}
 done
 wget $PIP_ROOT_URL/get-pip.py
-for pyver in 3.7 3.8 3.9 3.10 3.11; do
+for pyver in 3.7 3.8 3.9 3.10 3.11 3.12; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk ${pybin}-distutils
     get_pip_fname="get-pip.py"


### PR DESCRIPTION
Python 3.12 beta 1 has been released - https://www.python.org/downloads/release/python-3120b1/

I found that on Alpine, I initially got an error
> configure: error: unrecognized options: --with-system-ffi

Googling, I found https://github.com/docker-library/python/issues/715. Looking at the logs for earlier Python versions built on this repository's Alpine, each one had
> configure: WARNING: --with(out)-system-ffi is ignored on this platform

So this is a deprecated flag that has finally been removed, and never affected this repository to begin with. I have removed it from Alpine.