### PR TITLE
Add Python 3.13 release candidate 1

### DIFF
--- a/docker/Dockerfile-alpine3.18-arm64v8
+++ b/docker/Dockerfile-alpine3.18-arm64v8
@@ -3,7 +3,7 @@
 FROM  --platform=linux/arm64/v8 alpine:3.18
 
 ARG PLATFORM=arm64v8
-ENV PYTHON_VERSIONS="3.8.18 3.9.18 3.10.13 3.11.6 3.12.0"
+ENV PYTHON_VERSIONS="3.8.18 3.9.18 3.10.13 3.11.6 3.12.0 3.13.0rc1"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/docker/Dockerfile-alpine3.18-x86_64
+++ b/docker/Dockerfile-alpine3.18-x86_64
@@ -2,7 +2,7 @@
 
 FROM alpine:3.18
 
-ENV PYTHON_VERSIONS="3.8.18 3.9.18 3.10.13 3.11.6 3.12.0"
+ENV PYTHON_VERSIONS="3.8.18 3.9.18 3.10.13 3.11.6 3.12.0 3.13.0rc1"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Pythons 2.7 3.6 3.7 3.8 3.9 3.10 3.11 3.12 and matching pips
+# Install Pythons 2.7 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 and matching pips
 set -ex
 
 echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes.list
@@ -22,7 +22,7 @@ for pyver in 3.6; do
     ${pybin} ${get_pip_fname}
 done
 wget $PIP_ROOT_URL/get-pip.py
-for pyver in 3.7 3.8 3.9 3.10 3.11 3.12; do
+for pyver in 3.7 3.8 3.9 3.10 3.11 3.12 3.13; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk ${pybin}-distutils
     get_pip_fname="get-pip.py"


### PR DESCRIPTION
Python 3.13.0 is now in release candidate phase, which makes it ABI stable. This commit adds the [first release candidate](https://pythoninsider.blogspot.com/2024/08/python-3130-release-candidate-1-released.html).

This PR follows the changes in last year's PR:

- https://github.com/multi-build/docker-images/pull/41
