### PR TITLE
Update Python to latest patch versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Ubuntu focal (20.04) docker images (64-bit) with Pythons:
 * 3.10
 * 3.11
 * 3.12
+* 3.13
 
 installed via ``apt-get install python2.7-dev`` (etc).
 

--- a/docker/Dockerfile-alpine3.18-arm64v8
+++ b/docker/Dockerfile-alpine3.18-arm64v8
@@ -3,7 +3,7 @@
 FROM  --platform=linux/arm64/v8 alpine:3.18
 
 ARG PLATFORM=arm64v8
-ENV PYTHON_VERSIONS="3.8.18 3.9.18 3.10.13 3.11.6 3.12.0 3.13.0rc1"
+ENV PYTHON_VERSIONS="3.8.19 3.9.19 3.10.14 3.11.9 3.12.5 3.13.0rc1"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/docker/Dockerfile-alpine3.18-x86_64
+++ b/docker/Dockerfile-alpine3.18-x86_64
@@ -2,7 +2,7 @@
 
 FROM alpine:3.18
 
-ENV PYTHON_VERSIONS="3.8.18 3.9.18 3.10.13 3.11.6 3.12.0 3.13.0rc1"
+ENV PYTHON_VERSIONS="3.8.19 3.9.19 3.10.14 3.11.9 3.12.5 3.13.0rc1"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.


### PR DESCRIPTION
Update to the latest patch version of Python 3.8 to 3.12.