### PR TITLE
Added Python 3.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
    - arch: s390x
      env: DIST="focal" PLATFORM="s390x"
    - arch: amd64
-     env: DIST="alpine3.20" PLATFORM="x86_64"
+     env: DIST="alpine3.22" PLATFORM="x86_64"
    - arch: arm64
-     env: DIST="alpine3.20" PLATFORM="arm64v8"
+     env: DIST="alpine3.22" PLATFORM="arm64v8"
 
 script:
   - DIST=$DIST PLATFORM=$PLATFORM TRAVIS_COMMIT=$TRAVIS_COMMIT ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: focal
+dist: noble
 services:
   - docker
 
@@ -10,13 +10,13 @@ cache:
 matrix:
   include:
    - arch: amd64
-     env: DIST="focal" PLATFORM="x86_64"
+     env: DIST="noble" PLATFORM="x86_64"
    - arch: arm64
-     env: DIST="focal" PLATFORM="arm64v8"
+     env: DIST="noble" PLATFORM="arm64v8"
    - arch: ppc64le
-     env: DIST="focal" PLATFORM="ppc64le"
+     env: DIST="noble" PLATFORM="ppc64le"
    - arch: s390x
-     env: DIST="focal" PLATFORM="s390x"
+     env: DIST="noble" PLATFORM="s390x"
    - arch: amd64
      env: DIST="alpine3.22" PLATFORM="x86_64"
    - arch: arm64
@@ -30,4 +30,4 @@ deploy:
   provider: script
   script: bash ./deploy.sh
   on:
-    branch: focal
+    branch: noble

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2024, Multibuild for python wheels
+Copyright (c) 2025, Multibuild for python wheels
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ Ubuntu noble (24.04) docker images (64-bit) with Pythons:
 * 3.11
 * 3.12
 * 3.13 (including 3.13-nogil)
+* 3.14 (including 3.14-nogil)
 
 installed via ``apt-get install python2.7-dev`` (etc).
 

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,6 @@ Ubuntu noble 64-bit images with Pythons installed
 
 Ubuntu noble (24.04) docker images (64-bit) with Pythons:
 
-* 2.7
-* 3.6
 * 3.7
 * 3.8
 * 3.9

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 ##################################################
-Ubuntu focal 64-bit images with Pythons installed
+Ubuntu noble 64-bit images with Pythons installed
 ##################################################
 
-Ubuntu focal (20.04) docker images (64-bit) with Pythons:
+Ubuntu noble (24.04) docker images (64-bit) with Pythons:
 
 * 2.7
 * 3.6
@@ -26,7 +26,7 @@ Extra development libraries left in the installation:
 - multibuild libraries
 - libffi-dev (needed for cffi)
 
-Use them via (for x86_64) ``docker run -it multibuild/focal_x86_64 /bin/bash``
+Use them via (for x86_64) ``docker run -it multibuild/noble_x86_64 /bin/bash``
 
 There are also alpine-based images for x86 and aarch64, where we build python
 versions not available from the distro.

--- a/docker/Dockerfile-alpine3.22-arm64v8
+++ b/docker/Dockerfile-alpine3.22-arm64v8
@@ -3,7 +3,7 @@
 FROM  --platform=linux/arm64/v8 alpine:3.22
 
 ARG PLATFORM=arm64v8
-ENV PYTHON_VERSIONS="3.8.19 3.9.19 3.10.14 3.11.9 3.12.7 3.13.0"
+ENV PYTHON_VERSIONS="3.8.20 3.9.24 3.10.19 3.11.14 3.12.12 3.13.9 3.14.0"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/docker/Dockerfile-alpine3.22-arm64v8
+++ b/docker/Dockerfile-alpine3.22-arm64v8
@@ -1,7 +1,8 @@
 # based on https://github.com/docker-library/python/blob/8d48af512dc58e9c29c9d4ee59477c195a29cbdc/3.10/alpine3.13/Dockerfile
 
-FROM alpine:3.20
+FROM  --platform=linux/arm64/v8 alpine:3.22
 
+ARG PLATFORM=arm64v8
 ENV PYTHON_VERSIONS="3.8.19 3.9.19 3.10.14 3.11.9 3.12.7 3.13.0"
 
 # http://bugs.python.org/issue19846

--- a/docker/Dockerfile-alpine3.22-x86_64
+++ b/docker/Dockerfile-alpine3.22-x86_64
@@ -2,7 +2,7 @@
 
 FROM alpine:3.22
 
-ENV PYTHON_VERSIONS="3.8.19 3.9.19 3.10.14 3.11.9 3.12.7 3.13.0"
+ENV PYTHON_VERSIONS="3.8.20 3.9.24 3.10.19 3.11.14 3.12.12 3.13.9 3.14.0"
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/docker/Dockerfile-alpine3.22-x86_64
+++ b/docker/Dockerfile-alpine3.22-x86_64
@@ -1,8 +1,7 @@
 # based on https://github.com/docker-library/python/blob/8d48af512dc58e9c29c9d4ee59477c195a29cbdc/3.10/alpine3.13/Dockerfile
 
-FROM  --platform=linux/arm64/v8 alpine:3.20
+FROM alpine:3.22
 
-ARG PLATFORM=arm64v8
 ENV PYTHON_VERSIONS="3.8.19 3.9.19 3.10.14 3.11.9 3.12.7 3.13.0"
 
 # http://bugs.python.org/issue19846

--- a/docker/Dockerfile-noble-arm64v8
+++ b/docker/Dockerfile-noble-arm64v8
@@ -1,6 +1,5 @@
-FROM ppc64le/ubuntu:focal
+FROM arm64v8/ubuntu:noble
 
-ARG PLATFORM=ppc64le
 RUN apt update
 RUN apt install -y gnupg
 # Script to choose Python version
@@ -10,12 +9,11 @@ COPY build_install_pythons.sh /
 # Install Pythons and matching pips
 RUN bash build_install_pythons.sh && rm build_install_pythons.sh
 
-# Install manylinux1 libraries. See:
-# https://www.python.org/dev/peps/pep-0513/#the-manylinux1-policy
+# Install manylinux2014 libraries. See:
+# https://peps.python.org/pep-0599/#the-manylinux2014-policy
 # https://github.com/multi-build/multibuild/issues/106
 RUN apt-get update && \
-        apt-get install -y libncurses5 libgcc1 libstdc++6 libc6 libx11-6 libxext6 \
-        libxrender1 libice6 libsm6 libgl1-mesa-glx libglib2.0-0
+        apt-get install -y libc6 libgcc1 libgl1 libglib2.0-0 libice6 libsm6 libstdc++6 libx11-6 libxext6 libxrender1 libssl-dev libffi-dev
 
 # Get virtualenv
 RUN pip3.10 install --user virtualenv

--- a/docker/Dockerfile-noble-ppc64le
+++ b/docker/Dockerfile-noble-ppc64le
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ppc64le/ubuntu:noble
 
 RUN apt update
 RUN apt install -y gnupg
@@ -9,12 +9,11 @@ COPY build_install_pythons.sh /
 # Install Pythons and matching pips
 RUN bash build_install_pythons.sh && rm build_install_pythons.sh
 
-# Install manylinux1 libraries. See:
-# https://www.python.org/dev/peps/pep-0513/#the-manylinux1-policy
+# Install manylinux2014 libraries. See:
+# https://peps.python.org/pep-0599/#the-manylinux2014-policy
 # https://github.com/multi-build/multibuild/issues/106
 RUN apt-get update && \
-        apt-get install -y libncurses5 libgcc1 libstdc++6 libc6 libx11-6 libxext6 \
-        libxrender1 libice6 libsm6 libgl1-mesa-glx libglib2.0-0
+        apt-get install -y libc6 libgcc1 libgl1 libglib2.0-0 libice6 libsm6 libstdc++6 libx11-6 libxext6 libxrender1
 
 # Get virtualenv
 RUN pip3.10 install --user virtualenv

--- a/docker/Dockerfile-noble-s390x
+++ b/docker/Dockerfile-noble-s390x
@@ -1,6 +1,5 @@
-FROM arm64v8/ubuntu:focal
+FROM s390x/ubuntu:noble
 
-ARG PLATFORM=arm64v8
 RUN apt update
 RUN apt install -y gnupg
 # Script to choose Python version
@@ -10,13 +9,11 @@ COPY build_install_pythons.sh /
 # Install Pythons and matching pips
 RUN bash build_install_pythons.sh && rm build_install_pythons.sh
 
-# Install manylinux1 libraries. See:
-# https://www.python.org/dev/peps/pep-0513/#the-manylinux1-policy
+# Install manylinux2014 libraries. See:
+# https://peps.python.org/pep-0599/#the-manylinux2014-policy
 # https://github.com/multi-build/multibuild/issues/106
 RUN apt-get update && \
-        apt-get install -y libncurses5 libgcc1 libstdc++6 libc6 libx11-6 libxext6 \
-        libxrender1 libice6 libsm6 libgl1-mesa-glx libglib2.0-0 libssl-dev \
-        libffi-dev
+        apt-get install -y libc6 libgcc1 libgl1 libglib2.0-0 libice6 libsm6 libstdc++6 libx11-6 libxext6 libxrender1
 
 # Get virtualenv
 RUN pip3.10 install --user virtualenv

--- a/docker/Dockerfile-noble-x86_64
+++ b/docker/Dockerfile-noble-x86_64
@@ -1,6 +1,5 @@
-FROM s390x/ubuntu:focal
+FROM ubuntu:noble
 
-ARG PLATFORM=s390x
 RUN apt update
 RUN apt install -y gnupg
 # Script to choose Python version
@@ -10,12 +9,11 @@ COPY build_install_pythons.sh /
 # Install Pythons and matching pips
 RUN bash build_install_pythons.sh && rm build_install_pythons.sh
 
-# Install manylinux1 libraries. See:
-# https://www.python.org/dev/peps/pep-0513/#the-manylinux1-policy
+# Install manylinux2014 libraries. See:
+# https://peps.python.org/pep-0599/#the-manylinux2014-policy
 # https://github.com/multi-build/multibuild/issues/106
 RUN apt-get update && \
-        apt-get install -y libncurses5 libgcc1 libstdc++6 libc6 libx11-6 libxext6 \
-        libxrender1 libice6 libsm6 libgl1-mesa-glx libglib2.0-0
+        apt-get install -y libc6 libgcc1 libgl1 libglib2.0-0 libice6 libsm6 libstdc++6 libx11-6 libxext6 libxrender1
 
 # Get virtualenv
 RUN pip3.10 install --user virtualenv

--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Pythons 2.7 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 and matching pips
+# Install Pythons 3.7 3.8 3.9 3.10 3.11 3.12 3.13 and matching pips
 set -ex
 
 echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu noble main" > /etc/apt/sources.list.d/deadsnakes.list
@@ -7,14 +7,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A755776
 apt-get update
 apt-get install -y wget
 PIP_ROOT_URL="https://bootstrap.pypa.io"
-for pyver in 2.7; do
-    pybin=python$pyver
-    apt install -y ${pybin} ${pybin}-dev ${pybin}-tk
-    wget $PIP_ROOT_URL/pip/$pyver/get-pip.py -O get-pip-$pyver.py
-    get_pip_fname="get-pip-${pyver}.py"
-    ${pybin} ${get_pip_fname}
-done
-for pyver in 3.6 3.7; do
+for pyver in 3.7; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk ${pybin}-distutils
     wget $PIP_ROOT_URL/pip/$pyver/get-pip.py -O get-pip-$pyver.py

--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Pythons 3.7 3.8 3.9 3.10 3.11 3.12 3.13 and matching pips
+# Install Pythons 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14 and matching pips
 set -ex
 
 echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu noble main" > /etc/apt/sources.list.d/deadsnakes.list
@@ -7,7 +7,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A755776
 apt-get update
 apt-get install -y wget
 PIP_ROOT_URL="https://bootstrap.pypa.io"
-for pyver in 3.7; do
+for pyver in 3.7 3.8; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk ${pybin}-distutils
     wget $PIP_ROOT_URL/pip/$pyver/get-pip.py -O get-pip-$pyver.py
@@ -16,24 +16,29 @@ for pyver in 3.7; do
 done
 wget $PIP_ROOT_URL/get-pip.py
 get_pip_fname="get-pip.py"
-for pyver in 3.8 3.9 3.10 3.11 3.12; do
+for pyver in 3.9 3.10 3.11; do
     pybin=python$pyver
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk ${pybin}-distutils
     ${pybin} ${get_pip_fname}
 done
-for pyver in 3.13; do
+for pyver in 3.13 3.14; do
     pybin=python$pyver
     # no -distutils
     apt install -y ${pybin} ${pybin}-dev ${pybin}-tk
     ${pybin} ${get_pip_fname}
 done
-for pyver in 3.13-nogil; do
+for pyver in 3.13-nogil 3.14-nogil; do
     pybin=python$pyver
     # only pybin
     apt install -y ${pybin}
     ${pybin} ${get_pip_fname}
 done
-BUILD_PKGS="zlib1g-dev libbz2-dev libncurses5-dev libreadline-gplv2-dev \
+for pyver in 3.12; do
+    pybin=python$pyver
+    # no -distutils
+    apt install -y ${pybin} ${pybin}-dev ${pybin}-tk python3-pip
+done
+BUILD_PKGS="zlib1g-dev libbz2-dev libncurses5-dev libreadline-dev \
     libsqlite3-dev libssl-dev libgdbm-dev tcl-dev tk-dev \
     liblzma-dev uuid-dev"
 apt-get -y install build-essential $BUILD_PKGS libffi-dev

--- a/docker/build_install_pythons.sh
+++ b/docker/build_install_pythons.sh
@@ -2,7 +2,7 @@
 # Install Pythons 2.7 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 and matching pips
 set -ex
 
-echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes.list
+echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu noble main" > /etc/apt/sources.list.d/deadsnakes.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A755776
 apt-get update
 apt-get install -y wget


### PR DESCRIPTION
Suggestion for https://github.com/multi-build/docker-images/issues/53. This is not necessarily to be merged - even if it is approved, you may wish to start a new branch.

This updates Alpine to 3.22, switches to Ubuntu 24.04, and adds Python 3.14.

It also drops Python 2.7 and 3.6, as [they are no longer supported by deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa), which helps https://github.com/multi-build/docker-images/issues/49.